### PR TITLE
Fix empty launch parameters interfering with manifest launch command

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -82,7 +82,7 @@ void MainWindow::setup() {
             QListWidgetItem *item = ui->listWidget->currentItem();
             ServerEntry *server = item->data(Qt::UserRole + 1).value<ServerEntry*>();
             QString args = settings->value("launchParams", "").toString();
-            proc->startDetached(server->client, server->args.split(" ") + args.split(" "));
+            proc->startDetached(server->client, args.split(" ") + server->args.split(" "));
         });
 
     /*


### PR DESCRIPTION
Changing the order that user and manifest launch params are combined fixes an issue where empty user launch params would mess up ones specified in the manifest.