### PR TITLE
Push file source URLs back in the queue if they are valid

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -209,7 +209,8 @@ void MainWindow::downloadItem(ManifestItem *item) {
             return;
         }
 
-        QNetworkRequest req(*item->urls.takeLast());
+        QUrl *url = item->urls.takeLast();
+        QNetworkRequest req(*url);
         req.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
         QNetworkReply *res = netMan.get(req);
         connect (
@@ -228,6 +229,7 @@ void MainWindow::downloadItem(ManifestItem *item) {
 
                res->deleteLater();
                file->commit();
+               item->urls.push_back(url);
                this->downloadItem(item);
 
             });


### PR DESCRIPTION
URLs are dequeued from a list of sources until a valid one can be downloaded. Swapping and validating manifests was failing because all the list of sources were empty after validating once. This is easily fixed by putting valid URLs back in the queue when downloading is complete.